### PR TITLE
Shoot from max focus distance to min focus distance

### DIFF
--- a/app/src/main/java/com/obsidium/focusbracket/FocusActivity.java
+++ b/app/src/main/java/com/obsidium/focusbracket/FocusActivity.java
@@ -229,9 +229,11 @@ public class FocusActivity extends BaseActivity implements SurfaceHolder.Callbac
         final int focusDiff = m_maxFocus - m_minFocus;
         final int pictureCount = m_pictureCounts.get(m_pictureCountIndex);
         final int step = (int)((float)focusDiff / (float)(pictureCount - 1));
-        int focus = m_minFocus;
-        for (int i = 0; i < pictureCount; ++i, focus += step)
-            m_focusQueue.addLast(focus);
+
+        for (int i = 0; i < pictureCount; i++) {
+            int focus = i * step + m_minFocus;
+            m_focusQueue.addFirst(focus);
+        }
     }
 
     private void initPictureCounts()


### PR DESCRIPTION
Before this commit you first set minimum focus. After that you set maximum focus. Therefore the focus
ring is in the maximum focus position. When starting shooting the app first moves focus to the minimum position. On 90mm lens this takes a long time. If we start shooting from the maximum position and move to the minimum after we will save some time at the beginning.

This commit reverses the shooting order so images are captured from the maximum focus distance to the minimum focus distance and therefore skipping the part where focus is being rolled all over the focus range at the beginning.

Related issue: https://github.com/obs1dium/FocusBracket/issues/9
